### PR TITLE
Tiling windows

### DIFF
--- a/Configs/Linux/Debian/KEYBINDINGS.md
+++ b/Configs/Linux/Debian/KEYBINDINGS.md
@@ -115,6 +115,10 @@
         <td>Alternate between the tiled and monocle layout</td>
     </tr>
     <tr>
+        <td><kbd>Super</kbd> + <kbd>Ctrl</kbd> + <kbd>P</kbd></td>
+        <td>Toggle focus follows pointer</td>
+    </tr>
+    <tr>
         <td><kbd>Super</kbd> + <kbd>1-7</kbd></td>
         <td>Focus on the given desktop</td>
     </tr>
@@ -131,8 +135,16 @@
         <td>Move focused window to {west, south, north, east}</td>
     </tr>
     <tr>
+        <td><kbd>Super</kbd> + <kbd>Alt</kbd> + { <kbd>Left</kbd>, <kbd>Down</kbd>, <kbd>Up</kbd>, <kbd>Right</kbd> }</td>
+        <td>Opens the next window to the {west,south,north,east}</td>
+    </tr>
+    <tr>
         <td><kbd>Super</kbd> + <kbd>Ctrl</kbd> + { <kbd>Left</kbd>, <kbd>Down</kbd>, <kbd>Up</kbd>, <kbd>Right</kbd> }</td>
         <td>Smart resize</td>
+    </tr>
+    <tr>
+        <td><kbd>Super</kbd> + <kbd>Ctrl</kbd> + { <kbd>-</kbd>, <kbd>+</kbd> }</td>
+        <td>Dynamic gap size</td>
     </tr>
 </table>
 

--- a/Configs/Linux/Debian/fjrodafo/.config/bspwm/bspwmrc
+++ b/Configs/Linux/Debian/fjrodafo/.config/bspwm/bspwmrc
@@ -29,6 +29,7 @@ bspc config window_gap 7
 bspc config split_ratio 0.5
 bspc config borderless_monocle true
 bspc config gapless_monocle true
+bspc config focus_follows_pointer true
 
 # Rules
 bspc rule -a Screenkey manage=off

--- a/Configs/Linux/Debian/fjrodafo/.config/sxhkd/sxhkdrc
+++ b/Configs/Linux/Debian/fjrodafo/.config/sxhkd/sxhkdrc
@@ -87,8 +87,8 @@ super + {_,shift + }{Left,Down,Up,Right}
 super + alt + {Left,Down,Up,Right}
 	bspc node -p {west,south,north,east}
 
-# smart resize, will grow or shrink depending on location.
-# will always grow for floating nodes.
+# smart resize, will grow or shrink depending on location
+# will always grow for floating nodes
 super + ctrl + {Left,Down,Up,Right}
   n=10; \
   { d1=left;   d2=right;  dx=-$n; dy=0;   \

--- a/Configs/Linux/Debian/fjrodafo/.config/sxhkd/sxhkdrc
+++ b/Configs/Linux/Debian/fjrodafo/.config/sxhkd/sxhkdrc
@@ -75,6 +75,10 @@ super + {_,shift + }a
 super + m
 	bspc desktop -l next
 
+# toggle focus follows pointer
+super + ctrl + p
+	bspc config focus_follows_pointer {false,true}
+
 # focus/send the node to the given desktop
 super + {_,shift + }{1-7}
 	bspc {desktop -f,node -d} '^{1-7}'

--- a/Configs/Linux/Debian/fjrodafo/.config/sxhkd/sxhkdrc
+++ b/Configs/Linux/Debian/fjrodafo/.config/sxhkd/sxhkdrc
@@ -83,6 +83,10 @@ super + {_,shift + }{1-7}
 super + {_,shift + }{Left,Down,Up,Right}
 	bspc node -{f,s} {west,south,north,east}
 
+# opens the next window to the given direction
+super + alt + {Left,Down,Up,Right}
+	bspc node -p {west,south,north,east}
+
 # smart resize, will grow or shrink depending on location.
 # will always grow for floating nodes.
 super + ctrl + {Left,Down,Up,Right}

--- a/Configs/Linux/Debian/fjrodafo/.config/sxhkd/sxhkdrc
+++ b/Configs/Linux/Debian/fjrodafo/.config/sxhkd/sxhkdrc
@@ -93,3 +93,7 @@ super + ctrl + {Left,Down,Up,Right}
   , d1=right;  d2=left;   dx=$n;  dy=0;   \
   } \
   bspc node --resize $d1 $dx $dy || bspc node --resize $d2 $dx $dy
+
+# dynamic gap size
+super + ctrl + {KP_Subtract,KP_Add}
+	bspc config -d focused window_gap "$(($(bspc config -d focused window_gap) {-,+} 7))"


### PR DESCRIPTION
## Summary

Add additional commands to improve the user experience with Tiling Windows.

## Details

* Toggle focus follows pointer.
* Opens the next window to the given direction.
* Dynamic gap size.

The changes made have been documented in [KEYBINDINGS.md](https://github.com/FJrodafo/Dotfiles/blob/tiling-windows/Configs/Linux/Debian/KEYBINDINGS.md)

## References

A tiling window manager based on binary space partitioning - [bspwm](https://github.com/baskerville/bspwm)

Simple X hotkey daemon - [sxhkd](https://github.com/baskerville/sxhkd)

## Checks

- [x] Tested changes
- [x] Stakeholder approval

## Issues

Closes #3 